### PR TITLE
Add rsyslog install for Debian 12 in fail2ban setup script

### DIFF
--- a/sh/install_fail2ban.sh
+++ b/sh/install_fail2ban.sh
@@ -37,6 +37,10 @@ install_fail2ban() {
     case "$OS" in
         ubuntu|debian)
             apt-get update
+            if [ "$OS" = "debian" ] && [ "$VERSION" = "12" ]; then
+                echo -e "${YELLOW}Detected Debian 12, installing rsyslog...${NC}"
+                apt-get install -y rsyslog
+            fi
             apt-get install -y fail2ban
             ;;
         centos|rhel|fedora)


### PR DESCRIPTION
Adds a conditional check in the install_fail2ban() function to automatically install rsyslog on Debian 12 systems. This is required because fail2ban depends on rsyslog for log monitoring, and Debian 12 may not include it by default.